### PR TITLE
Fix removal of sliced atoms

### DIFF
--- a/example/index.tsx
+++ b/example/index.tsx
@@ -29,7 +29,7 @@ const FormList = ({ todos }: { todos: typeof RecursiveFormAtom }) => {
       {atoms.map((atom, i) => (
         <>
           Form nr ({i})
-          <Form formAtom={atom} onRemove={atom.remove} />
+          <Form key={i} formAtom={atom} onRemove={atom.remove} />
         </>
       ))}
       <button
@@ -37,7 +37,7 @@ const FormList = ({ todos }: { todos: typeof RecursiveFormAtom }) => {
           entriesFocus.update(oldValue => [
             ...oldValue,
             [
-              `form${Math.random()+ 1}`,
+              `form${Math.random() + 1}`,
               {
                 name: 'New name',
                 otherAttribute: 'value',
@@ -68,7 +68,7 @@ const Form = ({
     entriesAtom.update(oldValue => [
       ...oldValue,
       ['Something new ' + Math.random(), 'New too'],
-    
+    ])
   }
   const nameAtom = focusAtom(formAtom, optic => optic.head())
   const name = useAtom(nameAtom)
@@ -82,8 +82,8 @@ const Form = ({
         }}
       />
       <ul>
-        {fieldAtoms.map(fieldAtom => (
-          <Field field={fieldAtom} onRemove={fieldAtom.remove} />
+        {fieldAtoms.map((fieldAtom, index) => (
+          <Field key={index} field={fieldAtom} onRemove={fieldAtom.remove} />
         ))}
         <li>
           <button onClick={addField}>Add new field</button>

--- a/src/atom.ts
+++ b/src/atom.ts
@@ -109,10 +109,14 @@ const derivedAtom = <Value, Update>(
     return cachedValue
   }
 
-  const subscribe = (listener: (value: Value) => void) => {
-    const dependencySubscription = dependencyObserver$.subscribe(_ => {
-      listener(getValue())
-    })
+  const subscribe = (
+    listener: (value: Value) => void,
+    errorHandler?: (error: unknown) => void,
+  ) => {
+    const dependencySubscription = dependencyObserver$.subscribe(
+      _ => listener(getValue()),
+      errorHandler,
+    )
     return () => dependencySubscription.unsubscribe()
   }
 

--- a/src/focus-atom.ts
+++ b/src/focus-atom.ts
@@ -71,9 +71,7 @@ function focusAtom<Value, FocusedValue>(
     case 'Equivalence':
     case 'Lens':
       return atom(
-        getAtomValue => {
-          return get(focus)(getAtomValue(baseAtom))
-        },
+        getAtomValue => get(focus)(getAtomValue(baseAtom)),
         (update: SetState<FocusedValue>) => {
           const nextValue = (update instanceof Function
             ? modify(focus)(update)
@@ -82,15 +80,10 @@ function focusAtom<Value, FocusedValue>(
         },
       )
     case 'Getter':
-      return atom(getAtomValue => {
-        return get(focus)(getAtomValue(baseAtom))
-      })
+      return atom(getAtomValue => get(focus)(getAtomValue(baseAtom)))
     case 'Prism':
       return atom(
-        getAtomValue => {
-          getAtomValue(baseAtom)
-          return preview(focus)(baseAtom.getValue())
-        },
+        getAtomValue => preview(focus)(getAtomValue(baseAtom)),
         (update: SetState<FocusedValue>) => {
           const nextValue = (update instanceof Function
             ? modify(focus)(update)

--- a/src/observe-for-one-value.ts
+++ b/src/observe-for-one-value.ts
@@ -4,9 +4,10 @@ import { ReadableAtom } from './types'
 
 const observeForOneValue = <T>(atom: ReadableAtom<T>): Observable<T> => {
   return new Observable<T>(observer => {
-    const unsubscribe = atom.subscribe(value => {
-      observer.next(value)
-    })
+    const unsubscribe = atom.subscribe(
+      value => observer.next(value),
+      error => observer.error(error),
+    )
     return () => {
       unsubscribe()
     }

--- a/src/react-utils.ts
+++ b/src/react-utils.ts
@@ -52,6 +52,13 @@ export const useSelector = <S, A>(
 export const useAtomSlice = <T>(
   arrayAtom: PrimitiveAtom<Array<T>>,
 ): Array<PrimitiveRemovableAtom<T>> => {
-  useAtom(atom(get => get(arrayAtom).length))
+  const previousArrayAtomRef = React.useRef<string>()
+  useAtom(
+    atom(get => {
+      console.log(previousArrayAtomRef.current)
+      previousArrayAtomRef.current = JSON.stringify(arrayAtom.getValue())
+      return get(arrayAtom).length
+    }),
+  )
   return sliceAtomArray(arrayAtom)
 }

--- a/src/slice-atom-array.ts
+++ b/src/slice-atom-array.ts
@@ -1,18 +1,31 @@
-import { optic, remove } from 'optics-ts'
-import focusAtom from './focus-atom'
-import { PrimitiveAtom, PrimitiveRemovableAtom } from './types'
+import { atom } from '.'
+import { PrimitiveAtom, PrimitiveRemovableAtom, SetState } from './types'
 
 const sliceAtomArray = <Value>(
   atomOfArray: PrimitiveAtom<Array<Value>>,
 ): Array<PrimitiveRemovableAtom<Value>> => {
   const getAtomAtIndex = (index: number) => {
-    const newAtom = focusAtom(atomOfArray, optic =>
-      optic.index(index),
-    ) as PrimitiveAtom<Value>
+    const newAtom = atom(
+      get => {
+        return get(atomOfArray)[index]
+      },
+      (update: SetState<Value>) => {
+        const oldValue = atomOfArray.getValue()[index]
+        const newValue = update instanceof Function ? update(oldValue) : update
+        atomOfArray.update(oldArr => [
+          ...oldArr.slice(0, index),
+          newValue,
+          ...oldArr.slice(index + 1),
+        ])
+      },
+    )
     return {
       ...newAtom,
       remove: () => {
-        atomOfArray.update(remove(optic<Array<Value>>().index(index)))
+        atomOfArray.update(oldArr => [
+          ...oldArr.slice(0, index),
+          ...oldArr.slice(index + 1),
+        ])
       },
     }
   }

--- a/src/slice-atom-array.ts
+++ b/src/slice-atom-array.ts
@@ -1,15 +1,30 @@
 import { atom } from '.'
 import { PrimitiveAtom, PrimitiveRemovableAtom, SetState } from './types'
 
+export class OutOfBoundsPrismError extends Error {
+  constructor(message: any) {
+    super(message)
+    this.name = 'OutOfBoundsPrismError'
+    Object.setPrototypeOf(this, OutOfBoundsPrismError.prototype)
+  }
+}
+
 const sliceAtomArray = <Value>(
   atomOfArray: PrimitiveAtom<Array<Value>>,
 ): Array<PrimitiveRemovableAtom<Value>> => {
   const getAtomAtIndex = (index: number) => {
     const newAtom = atom(
       get => {
+        if (index >= atomOfArray.getValue().length) {
+          const err = new OutOfBoundsPrismError("this shouldn't happen")
+          throw err
+        }
         return get(atomOfArray)[index]
       },
       (update: SetState<Value>) => {
+        if (index >= atomOfArray.getValue().length) {
+          throw new OutOfBoundsPrismError("this shouldn't happen")
+        }
         const oldValue = atomOfArray.getValue()[index]
         const newValue = update instanceof Function ? update(oldValue) : update
         atomOfArray.update(oldArr => [

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,10 @@
 export type SetState<S> = S | ((newValue: S) => S)
 
 export type ReadableAtom<Value> = {
-  subscribe: (listener: (value: Value) => void) => () => void
+  subscribe: (
+    listener: (value: Value) => void,
+    errorListener?: (error: unknown) => void,
+  ) => () => void
   getValue: () => Value
 }
 

--- a/test/use-atom.test.tsx
+++ b/test/use-atom.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import * as rtl from '@testing-library/react'
 import { atom } from '../src'
 import { PrimitiveAtom } from '../src/types'
-import { useAtom } from '../src/react-utils'
+import { useAtom, useAtomSlice } from '../src/react-utils'
 import focusAtom from '../src/focus-atom'
 
 it('focus on an atom works', async () => {
@@ -96,4 +96,73 @@ it('focus on a derived atom works', async () => {
   await findByText('focusedAtom: 8')
   await findByText('bigAtom: {"a":8}')
   await findByText('derivedAtom: 9')
+})
+
+it('removal works without throwing', async () => {
+  const arrArrAtom = atom([['hello', 'hello 2']])
+  const Item = ({
+    stringAtom,
+    remove,
+    index,
+  }: {
+    index: number
+    stringAtom: PrimitiveAtom<string>
+    remove: () => void
+  }) => {
+    const str = useAtom(stringAtom)
+    return (
+      <div>
+        <input value={str} onChange={e => stringAtom.update(e.target.value)} />
+        <button onClick={remove}>remove item {index}</button>
+      </div>
+    )
+  }
+
+  const ItemList = ({
+    arrAtom,
+    remove,
+    index,
+  }: {
+    index: number
+    arrAtom: PrimitiveAtom<string[]>
+    remove: () => void
+  }) => {
+    const atoms = useAtomSlice(arrAtom)
+    return (
+      <div>
+        {atoms.map((atom, index) => (
+          <Item
+            index={index}
+            key={index}
+            stringAtom={atom}
+            remove={atom.remove}
+          />
+        ))}
+        <button onClick={remove}>remove array {index}</button>
+      </div>
+    )
+  }
+
+  const App = () => {
+    const atoms = useAtomSlice(arrArrAtom)
+    return (
+      <div>
+        <h1>Klyva</h1>
+        {atoms.map((atom, index) => (
+          <ItemList
+            key={index}
+            index={index}
+            arrAtom={atom}
+            remove={atom.remove}
+          />
+        ))}
+      </div>
+    )
+  }
+
+  const { getByText } = rtl.render(<App />)
+
+  rtl.fireEvent.click(getByText('remove item 0'))
+  rtl.fireEvent.click(getByText('remove item 1'))
+  //rtl.fireEvent.click(getByText('remove array'))
 })

--- a/test/use-atom.test.tsx
+++ b/test/use-atom.test.tsx
@@ -163,6 +163,6 @@ it('removal works without throwing', async () => {
   const { getByText } = rtl.render(<App />)
 
   rtl.fireEvent.click(getByText('remove item 0'))
-  rtl.fireEvent.click(getByText('remove item 1'))
+  rtl.fireEvent.click(getByText('remove item 0'))
   //rtl.fireEvent.click(getByText('remove array'))
 })


### PR DESCRIPTION
This is due to that, for example when an Atom<string[]> is being sliced,
if the parent, that slices the atom, removes an item which one of the
sliced atoms points to, then when the child recalculates its value, it will get
an undefined reference. But React unsubscribes to the value first, so it doesnt matter.

This is due to that the parent, which is slicing the atoms, always "unmounts" the child
before the child needs to recalculate its value, and its only in this recalculation
the error happens - but it does happen.

I wasn't able to reproduce this in test cases unfortunately.