### PR TITLE
fix(reset-all): Add ability to at module level reset all atoms values

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-export { atom } from './atom'
+export { atom, resetAll } from './atom'
 export * from './react-utils'
 export { default as focusAtom } from './focus-atom'
 export { default as localStorageAtom } from './localstorage-atom'

--- a/test/use-reset-all.test.tsx
+++ b/test/use-reset-all.test.tsx
@@ -1,0 +1,37 @@
+import { atom, resetAll } from '../src'
+
+it('works to reset all atoms (without subscriptions)', () => {
+  const baseAtom = atom(0)
+  const derivedAtom = atom(get => get(baseAtom) + 1)
+
+  expect(baseAtom.getValue()).toBe(0)
+  expect(derivedAtom.getValue()).toBe(1)
+
+  baseAtom.update(value => value + 1)
+
+  expect(baseAtom.getValue()).toBe(1)
+  expect(derivedAtom.getValue()).toBe(2)
+
+  resetAll()
+
+  expect(baseAtom.getValue()).toBe(0)
+  expect(derivedAtom.getValue()).toBe(1)
+})
+
+it('works to reset all atoms (with subscriptions)', () => {
+  const baseAtom = atom(0)
+
+  let latestBaseAtomValue = baseAtom.getValue()
+
+  baseAtom.subscribe(value => (latestBaseAtomValue = value))
+
+  expect(latestBaseAtomValue).toBe(0)
+
+  baseAtom.update(value => value + 1)
+
+  expect(latestBaseAtomValue).toBe(1)
+
+  resetAll()
+
+  expect(latestBaseAtomValue).toBe(0)
+})


### PR DESCRIPTION
Adds a way to reset all atoms. Since all atoms are derived in some way from a base atom, it's enough to just reset all base atoms.

fixes: https://github.com/merisbahti/klyva/issues/12

What do you think sesam?