### PR TITLE
Use Object.is for comparison, instead of `fastDeepEqual`

### DIFF
--- a/examples/mega-form/index.tsx
+++ b/examples/mega-form/index.tsx
@@ -135,19 +135,16 @@ const Field = ({
   field: PrimitiveAtom<[string, string]>
   onRemove: () => void
 }) => {
-  const [[name, value], setField] = useAtom(field)
+  const [name, setName] = useAtom(focusAtom(field, optic => optic.index(0)))
+  const [value, setValue] = useAtom(focusAtom(field, optic => optic.index(1)))
 
   return (
     <li>
-      <input
-        type="text"
-        value={name}
-        onChange={e => setField(oldValue => [e.target.value, oldValue[1]])}
-      />
+      <input type="text" value={name} onChange={e => setName(e.target.value)} />
       <input
         type="text"
         value={value}
-        onChange={e => setField(oldValue => [oldValue[0], e.target.value])}
+        onChange={e => setValue(e.target.value)}
       />
       <button onClick={onRemove}>X</button>
     </li>

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "callbag-subscribe": "^1.5.1",
     "callbag-take": "^1.5.0",
     "callbag-tap": "^1.3.0",
-    "fast-deep-equal": "^3.1.3",
     "optics-ts": "1.1.0"
   }
 }

--- a/src/equal.ts
+++ b/src/equal.ts
@@ -1,7 +1,5 @@
-import fastDeepEqual from 'fast-deep-equal'
-
 const equal = (l1: any, l2: any) => {
-  return fastDeepEqual(l1, l2)
+  return Object.is(l1, l2)
 }
 
 export default equal

--- a/src/react-utils.ts
+++ b/src/react-utils.ts
@@ -57,7 +57,7 @@ export const useSelector: UseSelector = (
     let prevSlice: any
     return atom(get => {
       const newSlice = selector(get(sourceAtom))
-      if (prevSlice !== undefined && !equals(newSlice, prevSlice)) {
+      if (prevSlice === undefined || !equals(newSlice, prevSlice)) {
         prevSlice = newSlice
       }
       return prevSlice

--- a/src/react-utils.ts
+++ b/src/react-utils.ts
@@ -53,16 +53,18 @@ export const useSelector: UseSelector = (
   selector: any = identity,
   equals = Object.is,
 ) => {
-  const selectorAtom = React.useMemo(() => {
-    let prevSlice: any
-    return atom(get => {
-      const newSlice = selector(get(sourceAtom))
-      if (prevSlice === undefined || !equals(newSlice, prevSlice)) {
-        prevSlice = newSlice
-      }
-      return prevSlice
-    })
-  }, [equals, selector, sourceAtom])
+  const latestValueRef = React.useRef<any>()
+  const selectorAtom = atom(get => {
+    const newSlice = selector(get(sourceAtom))
+    if (
+      latestValueRef.current === undefined ||
+      !equals(newSlice, latestValueRef.current)
+    ) {
+      latestValueRef.current = newSlice
+    }
+    return latestValueRef.current
+  })
+
   return useAtom(selectorAtom)[0]
 }
 

--- a/src/react-utils.ts
+++ b/src/react-utils.ts
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react'
+import React from 'react'
 import { unstable_batchedUpdates } from 'react-dom'
 import { atom } from './atom'
 import {
@@ -39,7 +39,11 @@ export function useAtom<Value, Updater = unknown>(
 }
 
 type UseSelector = {
-  <S, A>(sourceAtom: ReadableAtom<S>, selector: (source: S) => A): A
+  <S, A>(
+    sourceAtom: ReadableAtom<S>,
+    selector: (source: S) => A,
+    equals?: (left: S, right: S) => boolean,
+  ): A
   <S>(sourceAtom: ReadableAtom<S>): S
 }
 
@@ -47,11 +51,18 @@ const identity = (id: any) => id
 export const useSelector: UseSelector = (
   sourceAtom: any,
   selector: any = identity,
+  equals = Object.is,
 ) => {
-  const selectorAtom = React.useMemo(
-    () => atom(get => selector(get(sourceAtom))),
-    [selector, sourceAtom],
-  )
+  const selectorAtom = React.useMemo(() => {
+    let prevSlice: any
+    return atom(get => {
+      const newSlice = selector(get(sourceAtom))
+      if (prevSlice !== undefined && !equals(newSlice, prevSlice)) {
+        prevSlice = newSlice
+      }
+      return prevSlice
+    })
+  }, [equals, selector, sourceAtom])
   return useAtom(selectorAtom)[0]
 }
 
@@ -61,22 +72,15 @@ export const useAtomSlice = <T>(
   arrayAtom: PrimitiveAtom<Array<T>>,
   filterBy?: (value: T) => boolean,
 ): Array<PrimitiveRemovableAtom<T>> => {
-  const latestValueRef = useRef([] as Array<number>)
-
   const keptIndexesAtom = atom(get => {
-    const newValue = filterBy
+    return filterBy
       ? get(arrayAtom).flatMap((value, index) => {
           return filterBy(value) ? [index] : []
         })
       : get(arrayAtom).map((_, index) => index)
-    const isNotEqual = !equalNumberArray(newValue, latestValueRef.current)
-    if (isNotEqual) {
-      latestValueRef.current = newValue
-    }
-    return latestValueRef.current
   })
 
-  const keptIndexes = useSelector(keptIndexesAtom)
+  const keptIndexes = useSelector(keptIndexesAtom, v => v, equalNumberArray)
 
   const sliced = sliceAtomArray(arrayAtom)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6164,7 +6164,7 @@ fast-deep-equal@^2.0.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
-fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
+fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==


### PR DESCRIPTION
And let the user decide what comparison function they want to use, by allowing a parameter in `useSelector`

What are the performance implications?

Megaform seems to have increased from 2-3ms per update to 3-4 or something. Is that a constant or multiplied?