### PR TITLE
Make verifyItem optional

### DIFF
--- a/src/localstorage-atom.ts
+++ b/src/localstorage-atom.ts
@@ -8,8 +8,9 @@ const localStorageAtom = <T>(
     Boolean(v ?? true),
 ) => {
   const storedItem = localStorage.getItem(key)
-  const parsedItem = storedItem ? JSON.parse(storedItem) : null
-  const initialItem = verifyItem(parsedItem) ? parsedItem : initialValue
+  const parsedItem = storedItem !== null ? JSON.parse(storedItem) : null
+  const initialItem =
+    parsedItem !== null && verifyItem(parsedItem) ? parsedItem : initialValue
 
   const baseAtom = atom(initialItem)
   const derivedAtom = atom(

--- a/src/localstorage-atom.ts
+++ b/src/localstorage-atom.ts
@@ -1,16 +1,32 @@
 import { atom } from './atom'
 import { SetState } from './types'
 
+type Verifier<T> = (v: unknown) => v is T
+
+const getInitialItem = <T>(
+  defaultValue: T,
+  key: string,
+  verifier?: Verifier<T>,
+) => {
+  const storedItem = localStorage.getItem(key)
+  if (storedItem === null) {
+    return defaultValue
+  }
+  try {
+    const parsedItem = JSON.parse(storedItem)
+    if (verifier?.(parsedItem)) {
+      return parsedItem
+    }
+  } catch (err) {}
+  return defaultValue
+}
+
 const localStorageAtom = <T>(
   initialValue: T,
   key: string,
-  verifyItem: (storedValue: unknown) => storedValue is T = (v): v is T =>
-    Boolean(v ?? true),
+  verifyItem?: Verifier<T>,
 ) => {
-  const storedItem = localStorage.getItem(key)
-  const parsedItem = storedItem !== null ? JSON.parse(storedItem) : null
-  const initialItem =
-    parsedItem !== null && verifyItem(parsedItem) ? parsedItem : initialValue
+  const initialItem = getInitialItem(initialValue, key, verifyItem)
 
   const baseAtom = atom(initialItem)
   const derivedAtom = atom(

--- a/src/localstorage-atom.ts
+++ b/src/localstorage-atom.ts
@@ -4,9 +4,8 @@ import { SetState } from './types'
 const localStorageAtom = <T>(
   initialValue: T,
   key: string,
-  verifyItem: (storedValue: unknown) => storedValue is T = (
-    v: unknown,
-  ): v is T => true,
+  verifyItem: (storedValue: unknown) => storedValue is T = (v): v is T =>
+    Boolean(v ?? true),
 ) => {
   const storedItem = localStorage.getItem(key)
   const parsedItem = storedItem ? JSON.parse(storedItem) : null

--- a/src/localstorage-atom.ts
+++ b/src/localstorage-atom.ts
@@ -14,7 +14,7 @@ const getInitialItem = <T>(
   }
   try {
     const parsedItem = JSON.parse(storedItem)
-    if (verifier?.(parsedItem)) {
+    if (!verifier || verifier(parsedItem)) {
       return parsedItem
     }
   } catch (err) {}

--- a/src/localstorage-atom.ts
+++ b/src/localstorage-atom.ts
@@ -4,7 +4,9 @@ import { SetState } from './types'
 const localStorageAtom = <T>(
   initialValue: T,
   key: string,
-  verifyItem: (storedValue: unknown) => storedValue is T,
+  verifyItem: (storedValue: unknown) => storedValue is T = (
+    v: unknown,
+  ): v is T => true,
 ) => {
   const storedItem = localStorage.getItem(key)
   const parsedItem = storedItem ? JSON.parse(storedItem) : null

--- a/test/localstorage-atom.test.ts
+++ b/test/localstorage-atom.test.ts
@@ -68,3 +68,20 @@ it('never calls verifier when no stored value', async () => {
   })
   expect(atom.getValue()).toBe(27)
 })
+
+it('correctly allows null to be stored', async () => {
+  localStorage.removeItem('myOtherKey')
+  localStorage.setItem('myOtherKey', JSON.stringify(null))
+  const atom = localStorageAtom(
+    'foo',
+    'myOtherKey',
+    (v): v is null | 'foo' => v === null || v === 'foo',
+  )
+  expect(atom.getValue()).toBe(null)
+})
+
+it('uses initial value when unable to parse stored value', async () => {
+  localStorage.setItem('myOtherKey', '{INVALID_JSON')
+  const atom = localStorageAtom('foo', 'myOtherKey')
+  expect(atom.getValue()).toBe('foo')
+})

--- a/test/localstorage-atom.test.ts
+++ b/test/localstorage-atom.test.ts
@@ -40,3 +40,31 @@ it('localstorage uses default argument if the item in localstorage failed valida
   expect(localStorage.getItem('myKey')).toBe('11')
   expect(atom.getValue()).toBe(11)
 })
+
+it('works when no stored value and no verifier', async () => {
+  localStorage.removeItem('myOtherKey')
+  const atom = localStorageAtom(27, 'myOtherKey')
+  expect(localStorage.getItem('myOtherKey')).toBe(null)
+  expect(atom.getValue()).toBe(27)
+  atom.update(20)
+  expect(localStorage.getItem('myOtherKey')).toBe('20')
+  expect(atom.getValue()).toBe(20)
+})
+
+it('works when stored value and no verifier', async () => {
+  localStorage.setItem('myOtherKey', '35')
+  const atom = localStorageAtom(27, 'myOtherKey')
+  expect(localStorage.getItem('myOtherKey')).toBe('35')
+  expect(atom.getValue()).toBe(35)
+  atom.update(20)
+  expect(localStorage.getItem('myOtherKey')).toBe('20')
+  expect(atom.getValue()).toBe(20)
+})
+
+it('never calls verifier when no stored value', async () => {
+  localStorage.removeItem('myOtherKey')
+  const atom = localStorageAtom(27, 'myOtherKey', (v): v is number => {
+    throw new Error(String(v))
+  })
+  expect(atom.getValue()).toBe(27)
+})


### PR DESCRIPTION
Two fixes to `localStorageAtom`:

* Make `verifyItem` optional by having a dummy default that always returns `true`
* Don't call `verifyItem` when there's no stored value, just used default