### PR TITLE
Meris/mixedup

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,13 +81,9 @@
   "dependencies": {
     "@types/deep-equal": "^1.0.1",
     "callbag-merge": "^3.2.2",
-    "callbag-merge-map": "^0.0.1",
-    "callbag-pipe": "^1.2.0",
     "callbag-share": "^1.2.0",
-    "callbag-skip": "^1.1.0",
     "callbag-subscribe": "^1.5.1",
     "callbag-take": "^1.5.0",
-    "callbag-tap": "^1.3.0",
     "optics-ts": "1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.7.0-beta.0",
+  "version": "0.7.0-beta.1",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.3",
+  "version": "0.7.0-beta.0",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "callbag-subscribe": "^1.5.1",
     "callbag-take": "^1.5.0",
     "callbag-tap": "^1.3.0",
-    "fast-deep-equal": "^3.1.3",
     "optics-ts": "1.1.0"
   }
 }

--- a/src/cached-subject.ts
+++ b/src/cached-subject.ts
@@ -1,12 +1,12 @@
 import { Callbag, Sink } from 'callbag'
 
-const behaviorSubject = <T>(
+const cachedSubject = <T>(
   initial: T,
 ): Callbag<T, T> & { getValue: () => T } => {
   let sinks: Sink<T>[] = []
   let latest = initial
 
-  const newBehaviorSubject = (type: 0 | 1 | 2, data: any) => {
+  const newCachedSubject = (type: 0 | 1 | 2, data: any) => {
     if (type === 0) {
       const callbag: Sink<T> = data
       sinks.push(callbag)
@@ -19,8 +19,6 @@ const behaviorSubject = <T>(
           }
         }
       })
-
-      data(1, latest)
     } else {
       if (type === 1) {
         latest = data
@@ -46,8 +44,8 @@ const behaviorSubject = <T>(
       }
     }
   }
-  newBehaviorSubject.getValue = () => latest
-  return newBehaviorSubject
+  newCachedSubject.getValue = () => latest
+  return newCachedSubject
 }
 
-export default behaviorSubject
+export default cachedSubject

--- a/src/equal.ts
+++ b/src/equal.ts
@@ -1,7 +1,5 @@
-import fastDeepEqual from 'fast-deep-equal'
-
 const equal = (l1: any, l2: any) => {
-  return fastDeepEqual(l1, l2)
+  return Object.is(l1, l2)
 }
 
 export default equal

--- a/src/react-utils.ts
+++ b/src/react-utils.ts
@@ -18,11 +18,11 @@ export function useAtom<Value>(atom: ReadableAtom<Value>): [Value]
 export function useAtom<Value, Updater = unknown>(
   atom: ReadableAtom<Value> & { update?: (updater: Updater) => void },
 ) {
-  const [cache, setCache] = React.useState(() => atom.getValue())
+  const [cache, setCache] = React.useState(atom.getValue)
   React.useEffect(() => {
-    setCache(atom.getValue())
-    const unsub = atom.subscribe(value => setCache(value))
-    return () => unsub()
+    setCache(atom.getValue)
+    const unsub = atom.subscribe(setCache)
+    return unsub
   }, [atom])
   const updaterMaybe: null | ((updater: Updater) => void) = React.useMemo(
     () =>

--- a/test/atom-derived.test.ts
+++ b/test/atom-derived.test.ts
@@ -187,3 +187,31 @@ test('composite atom works after resubscribe', done => {
 
   done()
 })
+
+test('composite atom works after resubscribe 2', done => {
+  const leftOrRight = atom<'left' | 'right'>('left')
+  const left = atom(-10)
+  const right = atom(10)
+  const derived = atom(get =>
+    get(leftOrRight) === 'left' ? get(left) : get(right),
+  )
+
+  leftOrRight.update('right')
+
+  let derivedUpdates = 0
+  let derivedValue = 0
+
+  derived.subscribe(v => {
+    derivedValue = v
+    derivedUpdates++
+  })
+
+  right.update(v => v + 1)
+
+  expect(derivedUpdates).toBe(1)
+  expect(derivedValue).toBe(11)
+
+  expect(derived.getValue()).toBe(11)
+
+  done()
+})

--- a/test/atom.test.ts
+++ b/test/atom.test.ts
@@ -97,27 +97,37 @@ test("the parent emits even though its the focused atom's focused atom being nex
   done()
 })
 
-test('identity is perserved for values, equal changes should not change idenitity', done => {
-  const value = { a: { b: 0 } }
+test('identity is perserved for unchanged values', done => {
+  const value = { a: { value: 0 }, b: { value: 10 } }
   const myAtom = atom(value)
   const focusA = focusAtom(myAtom, optic => optic.prop('a'))
+  const focusAFocusValue = focusAtom(focusA, optic => optic.prop('value'))
 
   let focusAUpdates = 0
   let myAtomUpdates = 0
   focusA.subscribe(() => (focusAUpdates += 1))
   myAtom.subscribe(() => (myAtomUpdates += 1))
 
-  myAtom.update({ a: { b: 0 } })
-  expect(focusAUpdates).toBe(0)
-  expect(myAtomUpdates).toBe(0)
-  expect(focusA.getValue()).toBe(value.a)
-  expect(myAtom.getValue()).toBe(value)
+  myAtom.update(oldValue => ({ ...oldValue, a: { value: 0 } }))
+  expect(focusAUpdates).toBe(1)
+  expect(myAtomUpdates).toBe(1)
+  expect(focusA.getValue()).toStrictEqual(value.a)
+  expect(myAtom.getValue()).toStrictEqual(value)
+  expect(myAtom.getValue().b).toBe(value.b)
 
-  focusA.update({ b: 0 })
-  expect(focusAUpdates).toBe(0)
-  expect(myAtomUpdates).toBe(0)
-  expect(focusA.getValue()).toBe(value.a)
-  expect(myAtom.getValue()).toBe(value)
+  focusA.update({ value: 0 })
+  expect(focusAUpdates).toBe(2)
+  expect(myAtomUpdates).toBe(2)
+  expect(focusA.getValue()).toStrictEqual(value.a)
+  expect(myAtom.getValue()).toStrictEqual(value)
+  expect(myAtom.getValue().b).toBe(value.b)
+
+  focusAFocusValue.update(0)
+  expect(focusAUpdates).toBe(3)
+  expect(myAtomUpdates).toBe(3)
+  expect(focusA.getValue()).toStrictEqual(value.a)
+  expect(myAtom.getValue()).toStrictEqual(value)
+  expect(myAtom.getValue().b).toBe(value.b)
 
   done()
 })

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -1,17 +1,1 @@
 // adds types to other packages
-
-declare module 'callbag-tap' {
-  import { Source } from 'callbag'
-
-  const tap: <T>(cb: (value: T) => void) => (source: Source<T>) => Source<T>
-  export default tap
-}
-
-declare module 'callbag-concat-map' {
-  import { Source } from 'callbag'
-
-  const concatMap: <T, B>(
-    cb: (value: T) => Source<B>,
-  ) => (source: Source<T>) => Source<B>
-  export default concatMap
-}

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -7,11 +7,11 @@ declare module 'callbag-tap' {
   export default tap
 }
 
-declare module 'callbag-merge-map' {
+declare module 'callbag-concat-map' {
   import { Source } from 'callbag'
 
-  const mergeMap: <T, B>(
+  const concatMap: <T, B>(
     cb: (value: T) => Source<B>,
   ) => (source: Source<T>) => Source<B>
-  export default mergeMap
+  export default concatMap
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4153,11 +4153,6 @@ call-me-maybe@^1.0.1:
   resolved "https://registry.yarnpkg.com/call-me-maybe/-/call-me-maybe-1.0.1.tgz#26d208ea89e37b5cbde60250a15f031c16a4d66b"
   integrity sha1-JtII6onje1y95gJQoV8DHBak1ms=
 
-callbag-merge-map@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/callbag-merge-map/-/callbag-merge-map-0.0.1.tgz#1075264686720a69698ec2cd1cf6be92ccfbc6b5"
-  integrity sha512-+pUUxaWOKQ+p5TbclV/3Gg6xiydDVHpIzWguwS1q8Xpi37ji6qF9NhZWOT4Cl/7tClICQt6pecSRRN0v5lU7Sw==
-
 callbag-merge@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/callbag-merge/-/callbag-merge-3.2.2.tgz#87e4a9705dfcea109908296397834d648e8ea435"
@@ -4165,22 +4160,10 @@ callbag-merge@^3.2.2:
   dependencies:
     callbag "^1.2.0"
 
-callbag-pipe@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/callbag-pipe/-/callbag-pipe-1.2.0.tgz#7c00f47774da0096a7c5afa8a14f7873b5be1daf"
-  integrity sha512-M+LdHUK0qJkm4CRe+I870ZzD/SnzcpTsfJRzFoB2hOkNXlrVdoj002KMkfdS4pHMfV6egzZFd8j+xJu6C4kwEQ==
-
 callbag-share@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/callbag-share/-/callbag-share-1.2.0.tgz#5ed2333ebf4cc952d878348bf11f649894a6b989"
   integrity sha512-Gt+D5lfJ/j3X5/3PiMPL8hHDPBmeQILZl2QYu+YJtSFz6PlNGQSL45aD4e4uoxMvhMZY9NpMHh7KRWia9PZA+g==
-  dependencies:
-    callbag "^1.1.0"
-
-callbag-skip@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/callbag-skip/-/callbag-skip-1.1.0.tgz#02df66e5519e8f5dec8f12284663974d7fe35c80"
-  integrity sha512-KodTVJFA1h1Z7iFvs2ocwtyvb+q38i/FJTabdMTmmPucQV+XpGH8e6BYxmYRznY4FQUTLM9e5Y5HqbUxT7ma1w==
   dependencies:
     callbag "^1.1.0"
 
@@ -4197,11 +4180,6 @@ callbag-take@^1.5.0:
   integrity sha512-8aOxp+gzfVQtDe+tk9PhKbC9QR9Vap4KFA0xccUiXFK9VjIS0fSt/Yi454viPpMhJkhRcx1BsjyF34Cj57W89A==
   dependencies:
     callbag "^1.1.0"
-
-callbag-tap@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/callbag-tap/-/callbag-tap-1.3.0.tgz#d35eb002deb35979cf388c3532d95fa9348e2cf2"
-  integrity sha512-K2SarqzmLgl2OuzPQY7sQc9JzJ/n3C9Xkug4bLJfuecnhTTv6+y7O1JJ5ky4yXyYZ1eWkMrztnheQhs62wBPhw==
 
 callbag@^1.1.0, callbag@^1.2.0, callbag@^1.3.0:
   version "1.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6164,7 +6164,7 @@ fast-deep-equal@^2.0.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
-fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
+fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==


### PR DESCRIPTION
PR where I test the effects of an optimized cacheSubject and using `Object.is` as a equality function.

The memory leak I test is: deopt megaform, hold `a` to force creating lots of atoms for about 3 minutes. See if it takes more time in the end (or if the UI freezes)