### PR TITLE
Clean up atom constructor

### DIFF
--- a/src/atom.ts
+++ b/src/atom.ts
@@ -29,13 +29,13 @@ export function atom<Value, Update = unknown>(
     }
     return derivedAtom(read)
   }
-  return basicAtom(read)
+  return baseAtom(read)
 }
 
 /**
- * Creates a basic read- and writable atom
+ * Creates a basic read- and writable atom around the given value
  */
-const basicAtom = <Value>(value: Value): Atom<Value> => {
+const baseAtom = <Value>(value: Value): Atom<Value> => {
   const subject = cachedSubject(value)
   const getValue = subject.getValue
 

--- a/src/atom.ts
+++ b/src/atom.ts
@@ -7,11 +7,14 @@ import { atomToSource } from './atom-to-source'
 import equal from './equal'
 import cachedSubject from './cached-subject'
 
+/**
+ * The main atom constructor. Will return Atom, ReadableAtom or CustomAtom
+ * depending on how it is called.
+ */
 export function atom<Value, Update>(
   value: DerivedAtomReader<Value>,
   write: (update: Update) => void,
 ): CustomAtom<Value, Update>
-
 export function atom<Value>(
   value: DerivedAtomReader<Value>,
 ): ReadableAtom<Value>
@@ -29,6 +32,9 @@ export function atom<Value, Update = unknown>(
   return basicAtom(read)
 }
 
+/**
+ * Creates a basic read- and writable atom
+ */
 const basicAtom = <Value>(value: Value): Atom<Value> => {
   const subject = cachedSubject(value)
   const getValue = subject.getValue
@@ -52,6 +58,9 @@ const basicAtom = <Value>(value: Value): Atom<Value> => {
   return { getValue, update, subscribe }
 }
 
+/**
+ * Creates a read-only atom derived from other atoms and/or other outside sources
+ */
 const derivedAtom = <Value>(
   read: DerivedAtomReader<Value>,
 ): ReadableAtom<Value> => {
@@ -144,6 +153,9 @@ const derivedAtom = <Value>(
   return { subscribe, getValue }
 }
 
+/**
+ * Creates an updatable atom derived from other atoms and/or other outside sources
+ */
 export const customAtom = <Value, Update>(
   read: DerivedAtomReader<Value>,
   write: (update: Update) => void,

--- a/src/atom.ts
+++ b/src/atom.ts
@@ -1,11 +1,11 @@
 import cbSubscribe from 'callbag-subscribe'
 import cbShare from 'callbag-share'
 import cbMerge from 'callbag-merge'
+import cbTake from 'callbag-take'
 import { Atom, ReadableAtom, DerivedAtomReader, Updater, CustomAtom } from './'
 import { atomToSource } from './atom-to-source'
 import equal from './equal'
 import cachedSubject from './cached-subject'
-import take from 'callbag-take'
 
 export function atom<Value, Update>(
   value: DerivedAtomReader<Value>,
@@ -21,10 +21,16 @@ export function atom<Value, Update = unknown>(
   write?: (update: Update) => void,
 ) {
   if (read instanceof Function) {
-    return derivedAtom(read, write)
+    if (write) {
+      return customAtom(read, write)
+    }
+    return derivedAtom(read)
   }
+  return basicAtom(read)
+}
 
-  const subject = cachedSubject(read)
+const basicAtom = <Value>(value: Value): Atom<Value> => {
+  const subject = cachedSubject(value)
   const getValue = subject.getValue
 
   const obs = cbShare(subject)
@@ -33,7 +39,7 @@ export function atom<Value, Update = unknown>(
     const unsub = cbSubscribe(listener)(obs)
     return () => unsub()
   }
-  const next = (next: Updater<Value>) => {
+  const update = (next: Updater<Value>) => {
     const nextValue = next instanceof Function ? next(getValue()) : next
     // Instead of distinctUntilChanged(equal), we do the check here so
     // that the latest value from the stream (obs) and subject.getValue()
@@ -43,12 +49,11 @@ export function atom<Value, Update = unknown>(
     }
   }
 
-  return atomConstructor(subscribe, getValue, next)
+  return { getValue, update, subscribe }
 }
 
-const derivedAtom = <Value, Update>(
+const derivedAtom = <Value>(
   read: DerivedAtomReader<Value>,
-  write?: (update: Update) => void,
 ): ReadableAtom<Value> => {
   const getter = (
     onDependency: (dep: {
@@ -82,7 +87,7 @@ const derivedAtom = <Value, Update>(
     // but we want to ignore the first value!
     const sources = Array.from(dependencies).map(atomToSource)
     // Out of all dependants, if just one changes, we want to complete the stream
-    const dependencyObserver = take(1)(cbMerge(...sources))
+    const dependencyObserver = cbTake(1)(cbMerge(...sources))
 
     return { computedValue, dependencyObserver } as const
   }
@@ -136,29 +141,16 @@ const derivedAtom = <Value, Update>(
       valueSubscription()
     }
   }
-
-  return atomConstructor(subscribe, getValue, write)
+  return { subscribe, getValue }
 }
 
-// Make this a better construcor, if update is set, it should be a RW atom, but if not, it should always return a ReadOnly atom
-const atomConstructor = <Value, Updater>(
-  subscribe: Subscribe<Value>,
-  getValue: () => Value,
-  update?: (updater: Updater) => void,
-) => {
-  if (update) {
-    const atom: CustomAtom<Value, Updater> = {
-      subscribe,
-      update,
-      getValue,
-    }
-    return atom
-  } else {
-    const readOnlyAtom: ReadableAtom<Value> = {
-      subscribe: subscribe,
-      getValue,
-    }
-    return readOnlyAtom
+export const customAtom = <Value, Update>(
+  read: DerivedAtomReader<Value>,
+  write: (update: Update) => void,
+): CustomAtom<Value, Update> => {
+  return {
+    ...derivedAtom(read),
+    update: write,
   }
 }
 

--- a/test/atom.types.ts
+++ b/test/atom.types.ts
@@ -1,0 +1,18 @@
+// This file ensures that we get correctly typed return value from atom creator
+
+import { Atom, CustomAtom, ReadableAtom, Updater } from '../src'
+import { atom } from '../src/atom'
+
+// When just passing in a value we get a regular Atom
+const a1: Atom<number> = atom(7)
+
+// If we pass in a getter we get a Readable atom of the type we apply that getter to
+const a2: ReadableAtom<number> = atom(get => get(a1))
+
+// If we also pass a write function we get a CustomAtom instead
+const a3: CustomAtom<number, Updater<number>> = atom(
+  get => get(a2),
+  () => {},
+)
+
+console.log('just to use all variables', a1, a2, a3)


### PR DESCRIPTION
Here's a take on cleaning up the structure and return typings in `atom.ts`:

* extract inner `basicAtom` function
* extract inner `derivedAtom` function
* extract inner `customAtom` function
* remove `atomConstructor`
* collapse `atom` into simply returning `basicAtom`, `derivedAtom` or `customAtom` depending on input
* add file to test return types of `atom` (this "passes" both on master and on this branch)

No behaviour change, this is all about tidying up types and making the code easier to reason about.